### PR TITLE
salesforce reset on deactivation

### DIFF
--- a/deactivation.php
+++ b/deactivation.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Deactivation plugin.
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Reset connection on SF deactivation.
+ */
+register_deactivation_hook( NGSF_PLUGIN_FILE, 'newsletterglue_sf_deactivation' );
+function newsletterglue_sf_deactivation() {
+    $integrations = get_option( 'newsletterglue_integrations' );
+    if( isset( $integrations[ 'salesforce' ] ) ) {
+        delete_option( 'newsletterglue_integrations' );
+    }
+}

--- a/salesforce-newsletterglue.php
+++ b/salesforce-newsletterglue.php
@@ -105,6 +105,7 @@ final class NG_Salesforce {
 	private function includes() {
 
 		require_once NGSF_PLUGIN_DIR . 'filters.php';
+		require_once NGSF_PLUGIN_DIR . 'deactivation.php';
 
 		if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 


### PR DESCRIPTION
### This PR resolves the following issue:

- When SF is active and admin disables the plugin (not disconnect), the settings page shows loading for an uncertain time.